### PR TITLE
Uses default module detection to avoid stack overflow exception

### DIFF
--- a/pshelp/init.sls
+++ b/pshelp/init.sls
@@ -10,7 +10,7 @@ UpdatePSHelp:
   cmd.run:
     - name: 'try
         {
-          Update-Help -SourcePath {{ pshelp.cachedir }} -Module (Get-Module -ListAvailable | Where HelpInfoUri) -Force -ErrorAction Stop
+          Update-Help -SourcePath {{ pshelp.cachedir }} -Force -ErrorAction Stop
         }
         catch
         {


### PR DESCRIPTION
State was sometimes failing with: `Process is terminated due to StackOverflowException.` Attempting to address this failure by reducing the overhead (`update-help` doesn't require the `-module` option)...